### PR TITLE
bump version for setup_miniconda action

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -40,7 +40,7 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml

--- a/.github/workflows/py3.yaml
+++ b/.github/workflows/py3.yaml
@@ -29,7 +29,7 @@ jobs:
         python-version: [3.6, 3.9]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Additional info about the build
       shell: bash


### PR DESCRIPTION
GitHub just deprecated some unsafe commands like `::set-env`, which is a good thing, but it breaks compatibility with the version 1 of the `setup-miniconda` action. This PR bumps up to `setup-miniconda` version 2.